### PR TITLE
feat: zerror内嵌error

### DIFF
--- a/utils_test.go
+++ b/utils_test.go
@@ -48,4 +48,6 @@ func TestNewApm(t *testing.T) {
 func TestNewZError(t *testing.T) {
 	err := NewZError(nil, "10086", "TestNewZError")
 	assert.Equal(t, "10086: TestNewZError", err.Error())
+	err = NewZError(nil, "10087", "TestNewZError", WithError(err))
+	assert.Equal(t, "10086: TestNewZError", err.Err.Error())
 }


### PR DESCRIPTION
在现有的日志记录里，每次遇到错误需要手动进行log.Error, 非常的麻烦

现进行全局按条件记录

以前：
```go
if err != nil {
    Log.Error(ctx, fmt.Errorf("%w", err))
    return hutils.NewZError(ctx, http.StatusInternalServerError, "")
}
```
现在
```go
if err != nil {
    return hutils.NewZError(ctx, http.StatusInternalServerError, "", WithError(err))
}


func HandleResponseErrorWithContext(...) {
    if respErr.Code >= http.StatusInternalServerError {
	app.Log.Error(ctx, fmt.Errorf("%w", zErr.GetError()))
    }
}
```